### PR TITLE
Upgrading serenity-core from 1.1.22-rc.15 to 1.1.24

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ ext {
     if (!project.hasProperty("bintrayApiKey")) {
         bintrayApiKey = ''
     }
-    serenityCoreVersion = '1.1.22-rc.15'
+    serenityCoreVersion = '1.1.24'
     cucumberJVMVersion = '1.2.4'
 
     versionCounter = new ProjectVersionCounter(isRelease: project.hasProperty("releaseBuild"))


### PR DESCRIPTION
#### Summary of this PR
Upgrading serenity-core  from 1.1.22-rc.15 to 1.1.24
#### Intended effect
Usage of serenity-core of last version
#### How should this be manually tested?
./gradlew build will use serenity-core 1.1.24, also it can be tested using `gradle dependencies` command
#### Side effects
N/A
#### Documentation
N/A
#### Relevant tickets
N/A
#### Screenshots (if appropriate)
N/A