### PR TITLE
Groovy upgrading to 2.4.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -104,7 +104,7 @@ dependencies {
     testCompile 'org.assertj:assertj-core:1.7.1'
     testCompile 'org.slf4j:slf4j-log4j12:1.7.7'
     testCompile 'org.codehaus.groovy:groovy-all:2.4.4'
-    testCompile("org.spockframework:spock-core:0.7-groovy-2.0") {
+    testCompile("org.spockframework:spock-core:1-groovy-2.4") {
         exclude group: "junit"
         exclude module: "groovy-all"
     }

--- a/build.gradle
+++ b/build.gradle
@@ -104,7 +104,7 @@ dependencies {
     testCompile 'org.assertj:assertj-core:1.7.1'
     testCompile 'org.slf4j:slf4j-log4j12:1.7.7'
     testCompile 'org.codehaus.groovy:groovy-all:2.4.4'
-    testCompile("org.spockframework:spock-core:1-groovy-2.4") {
+    testCompile("org.spockframework:spock-core:0.7-groovy-2.0") {
         exclude group: "junit"
         exclude module: "groovy-all"
     }

--- a/build.gradle
+++ b/build.gradle
@@ -103,7 +103,7 @@ dependencies {
     }
     testCompile 'org.assertj:assertj-core:1.7.1'
     testCompile 'org.slf4j:slf4j-log4j12:1.7.7'
-    testCompile 'org.codehaus.groovy:groovy-all:2.3.6'
+    testCompile 'org.codehaus.groovy:groovy-all:2.4.4'
     testCompile("org.spockframework:spock-core:0.7-groovy-2.0") {
         exclude group: "junit"
         exclude module: "groovy-all"


### PR DESCRIPTION
#### Summary of this PR
Upgrade groovy version from 2.3 to 2.4.4
#### Intended effect
[gradle 2.10](https://docs.gradle.org/2.10/release-notes) can be used, and all it features
#### How should this be manually tested?
./gradlew build will use 2.10 plugin and 2.4.4 groovy
#### Side effects
N/A
#### Documentation
N/A
#### Relevant tickets
N/A
#### Screenshots (if appropriate)
N/A