### PR TITLE
Updating of serenity core version to rc.5, fix comparability issue 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ ext {
     if (!project.hasProperty("bintrayApiKey")) {
         bintrayApiKey = ''
     }
-    serenityCoreVersion = '1.1.24'
+    serenityCoreVersion = '1.1.25-rc.4'
     cucumberJVMVersion = '1.2.4'
 
     versionCounter = new ProjectVersionCounter(isRelease: project.hasProperty("releaseBuild"))
@@ -85,7 +85,8 @@ test {
 configurations.all {
     resolutionStrategy {
         // fail fast on dependency convergence problems
-        //failOnVersionConflict()
+        failOnVersionConflict()
+        force  'commons-collections:commons-collections:3.2.2'
     }
 }
 
@@ -212,4 +213,9 @@ bintray {
         licenses = ['Apache-2.0']
         labels = ['serenity','bdd','cucumber']
     }
+}
+
+task copyDeps(type: Copy) {
+    from configurations.runtime + configurations.testCompile
+    into project.projectDir.path + "/lib"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ ext {
     if (!project.hasProperty("bintrayApiKey")) {
         bintrayApiKey = ''
     }
-    serenityCoreVersion = '1.1.25-rc.4'
+    serenityCoreVersion = '1.1.25-rc.5'
     cucumberJVMVersion = '1.2.4'
 
     versionCounter = new ProjectVersionCounter(isRelease: project.hasProperty("releaseBuild"))

--- a/src/main/java/net/serenitybdd/cucumber/SerenityReporter.java
+++ b/src/main/java/net/serenitybdd/cucumber/SerenityReporter.java
@@ -236,7 +236,7 @@ public class SerenityReporter implements Formatter, Reporter {
     }
 
     private void configureDriver(Feature feature) {
-        StepEventBus.getEventBus().setUniqueSession(systemConfiguration.getUseUniqueBrowser());
+        StepEventBus.getEventBus().setUniqueSession(systemConfiguration.shouldUseAUniqueBrowser());
 
         List<String> tags = getTagNamesFrom(feature.getTags());
 

--- a/src/test/groovy/net/serenitybdd/cucumber/outcomes/WhenCreatingSerenityTestOutcomes.groovy
+++ b/src/test/groovy/net/serenitybdd/cucumber/outcomes/WhenCreatingSerenityTestOutcomes.groovy
@@ -66,13 +66,12 @@ class WhenCreatingSerenityTestOutcomes extends Specification {
         runtime.run();
         def recordedTestOutcomes = new TestOutcomeLoader().forFormat(OutcomeFormat.JSON).loadFrom(outputDirectory);
         def testOutcome = recordedTestOutcomes[0]
-        def stepResults = testOutcome.testSteps.collect { step -> step.result }
 
         then:
         testOutcome.result == TestResult.SUCCESS
 
         and:
-        stepResults == [TestResult.SUCCESS,TestResult.SUCCESS,TestResult.SUCCESS,TestResult.SUCCESS]
+        testOutcome.testSteps.collect { step -> step.result } == [TestResult.SUCCESS,TestResult.SUCCESS,TestResult.SUCCESS,TestResult.SUCCESS]
     }
 
     def "should record failures for a failing scenario"() {

--- a/src/test/groovy/net/serenitybdd/cucumber/web/WhenRunningWebCucumberStories.groovy
+++ b/src/test/groovy/net/serenitybdd/cucumber/web/WhenRunningWebCucumberStories.groovy
@@ -150,7 +150,7 @@ public class WhenRunningWebCucumberStories extends Specification {
         then:
         systemConfiguration.getBaseUrl() == "some-base-url"
         systemConfiguration.getElementTimeout() == 5
-        systemConfiguration.getUseUniqueBrowser() == true
+        systemConfiguration.shouldUseAUniqueBrowser() == true
 
     }
 


### PR DESCRIPTION
#### Summary of this PR
Updating dependency for using last serenity core
#### Intended effect
Will be used commons-collections:commons-collections:3.2.2 instead of 3.2.1 as in selenium 2.50.1. 
Also junit with version 4.12 will be used. Null pointer during test fixing
#### How should this be manually tested?
Project with last serenity core should be build. Also java 8 can be used in jbehave tests
#### Side effects
N/A
#### Documentation
N/A
#### Relevant tickets
N/A
#### Screenshots (if appropriate)
N/A