### PR TITLE
Updated serenity-core to 1.1.26

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ ext {
     if (!project.hasProperty("bintrayApiKey")) {
         bintrayApiKey = ''
     }
-    serenityCoreVersion = '1.1.26-rc.1'
+    serenityCoreVersion = '1.1.26'
     cucumberJVMVersion = '1.2.4'
 
     versionCounter = new ProjectVersionCounter(isRelease: project.hasProperty("releaseBuild"))


### PR DESCRIPTION
#### Summary of this PR
Updating serenity-core to 1.1.26
#### Intended effect
Current module can work with latest serenity-core
#### How should this be manually tested?
Projects should be able to build with current version of module and 1.1.26 serenity-core
#### Side effects
N/A
#### Documentation
N/A
#### Relevant tickets
N/A
#### Screenshots (if appropriate)
N/A