### PR TITLE
Do not close webdriver for each feature, fixes #72

### DIFF
--- a/src/main/java/net/serenitybdd/cucumber/SerenityReporter.java
+++ b/src/main/java/net/serenitybdd/cucumber/SerenityReporter.java
@@ -144,7 +144,6 @@ public class SerenityReporter implements Formatter, Reporter {
     @Override
     public void feature(Feature feature) {
 
-        assureTestSuiteFinished();
         if (feature.getName().isEmpty()) {
             feature = featureWithDefaultName(feature, defaultFeatureName, defaultFeatureId);
         }


### PR DESCRIPTION
 - SerenityReporter called assureTestSuiteFinished on beginning a new
   feature - this closed the current webdriver.
 - Fixes #72 (Cucumber + Serenity serenity.use.unique.browser does not
   work)