### PR TITLE
Fix serenity-cucumber issue #120

### DIFF
--- a/src/main/java/cucumber/runtime/formatter/SerenityReporter.java
+++ b/src/main/java/cucumber/runtime/formatter/SerenityReporter.java
@@ -212,7 +212,7 @@ public class SerenityReporter implements Formatter {
                 if (currentScenarioDefinition instanceof ScenarioOutline) {
                     examplesRunning = true;
                     addingScenarioOutlineSteps = true;
-                    examples(currentFeature.getName(), ((ScenarioOutline) currentScenarioDefinition).getTags(), currentScenarioDefinition.getName(), ((ScenarioOutline) currentScenarioDefinition).getExamples());
+                    examples(currentFeature, ((ScenarioOutline) currentScenarioDefinition).getTags(), currentScenarioDefinition.getName(), ((ScenarioOutline) currentScenarioDefinition).getExamples());
                 }
                 startOfScenarioLifeCycle(currentFeature, currentScenarioDefinition, event.testCase.getLine());
                 currentScenario = scenarioIdFrom(currentFeature.getName(), TestSourcesModel.convertToId(currentScenarioDefinition.getName()));
@@ -327,11 +327,13 @@ public class SerenityReporter implements Formatter {
         return requestedDriver;
     }
 
-    private void examples(String featureName, List<Tag> scenarioOutlineTags, String id, List<Examples> examplesList) {
+    private void examples(Feature currentFeature, List<Tag> scenarioOutlineTags, String id, List<Examples> examplesList) {
+        String featureName = currentFeature.getName();
+        List<Tag> currentFeatureTags = currentFeature.getTags();
         addingScenarioOutlineSteps = false;
         initializeExamples();
         for (Examples examples : examplesList) {
-            if (examplesAreNotExcludedByTags(examples, scenarioOutlineTags)) {
+            if (examplesAreNotExcludedByTags(examples, scenarioOutlineTags, currentFeatureTags)) {
                 List<TableRow> examplesTableRows = examples.getTableBody();
                 List<String> headers = getHeadersFrom(examples.getTableHeader());
                 List<Map<String, String>> rows = getValuesFrom(examplesTableRows, headers);
@@ -354,15 +356,15 @@ public class SerenityReporter implements Formatter {
         }
     }
 
-    private boolean examplesAreNotExcludedByTags(Examples examples, List<Tag> scenarioOutlineTags) {
+    private boolean examplesAreNotExcludedByTags(Examples examples, List<Tag> scenarioOutlineTags, List<Tag> currentFeatureTags) {
         if (testRunHasFilterTags()) {
-            return examplesMatchFilter(examples, scenarioOutlineTags);
+            return examplesMatchFilter(examples, scenarioOutlineTags, currentFeatureTags);
         }
         return true;
     }
 
-    private boolean examplesMatchFilter(Examples examples, List<Tag> scenarioOutlineTags) {
-        List<Tag> allExampleTags = getExampleAllTags(examples, scenarioOutlineTags);
+    private boolean examplesMatchFilter(Examples examples, List<Tag> scenarioOutlineTags, List<Tag> currentFeatureTags) {
+        List<Tag> allExampleTags = getExampleAllTags(examples, scenarioOutlineTags, currentFeatureTags);
         if (examplesHaveFilterTags(allExampleTags)) {
             List<String> allTagsForAnExampleScenario = allExampleTags.stream().map(Tag::getName).collect(Collectors.toList());
             String TagValuesFromCucumberOptions = getCucumberRuntimeTags().get(0);
@@ -390,15 +392,15 @@ public class SerenityReporter implements Formatter {
         return allTags.size() > 0;
     }
 
-    private List<Tag> getExampleAllTags(Examples examples, List<Tag> scenarioOutlineTags) {
+    private List<Tag> getExampleAllTags(Examples examples, List<Tag> scenarioOutlineTags, List<Tag> currentFeatureTags) {
         List<Tag> exampleTags = examples.getTags();
         List<Tag> allTags = new ArrayList<>();
         if (exampleTags != null)
             allTags.addAll(exampleTags);
         if (scenarioOutlineTags != null)
             allTags.addAll(scenarioOutlineTags);
-        if (featureTags != null && featureTags.size() > 0)
-            allTags.addAll(featureTags);
+        if (currentFeatureTags !=null)
+	        allTags.addAll(currentFeatureTags);
         return allTags;
     }
 

--- a/src/smoketests/src/test/java/smoketests/WhenRootFolderOfFeaturesAloneProvided.java
+++ b/src/smoketests/src/test/java/smoketests/WhenRootFolderOfFeaturesAloneProvided.java
@@ -1,0 +1,13 @@
+package smoketests;
+
+import cucumber.api.CucumberOptions;
+import net.serenitybdd.cucumber.CucumberWithSerenity;
+import org.junit.runner.RunWith;
+
+/**
+ * Created by Ramanathan Raghunathan on 18/12/2014.
+ */
+@RunWith(CucumberWithSerenity.class)
+@CucumberOptions(features="src/test/resources/features",
+glue= {"smoketests.stepdefinitions"},tags = {"@tag_test"})
+public class WhenRootFolderOfFeaturesAloneProvided {}

--- a/src/smoketests/src/test/java/smoketests/WhenUsingScenarioOutlineAndTagsAtAllLevels.java
+++ b/src/smoketests/src/test/java/smoketests/WhenUsingScenarioOutlineAndTagsAtAllLevels.java
@@ -9,5 +9,5 @@ import org.junit.runner.RunWith;
  */
 @RunWith(CucumberWithSerenity.class)
 @CucumberOptions(features="src/test/resources/features/tags_and_report/serenity_report_when_using_tags_at_all_level.feature",
-glue= {"smoketests.stepdefinitions"},tags = {"@tag_test,@doing_maths","@single_red"})
+glue= {"smoketests.stepdefinitions"},tags = {"(@tag_test or @doing_maths) and @single_red"})
 public class WhenUsingScenarioOutlineAndTagsAtAllLevels {}

--- a/src/test/groovy/net/serenitybdd/cucumber/outcomes/WhenCreatingSerenityTestOutcomesForTableDrivenScenarios.groovy
+++ b/src/test/groovy/net/serenitybdd/cucumber/outcomes/WhenCreatingSerenityTestOutcomesForTableDrivenScenarios.groovy
@@ -338,7 +338,7 @@ class WhenCreatingSerenityTestOutcomesForTableDrivenScenarios extends Specificat
 
     def "should handle example tables with tag on first example"() {
         given:
-        def runtime = serenityRunnerForCucumberTestRunner(TablesAndExamplesTagsSingleDigitsScenario.class, outputDirectory);
+        def runtime = serenityRunnerForCucumberTestRunner(RunOnlyFirstExampleTableRows.class, outputDirectory);
 
         when:
         runtime.run();
@@ -346,13 +346,13 @@ class WhenCreatingSerenityTestOutcomesForTableDrivenScenarios extends Specificat
         def testOutcome = recordedTestOutcomes[0]
 
         then:
-        testOutcome.getTags().collect{testTag-> testTag.normalisedName()}.contains("single_digits")
+        testOutcome.getTags().collect{testTag-> testTag.normalisedName()}.contains("example_one")
         testOutcome.dataTable.rows.collect { it.result } == [SUCCESS, SUCCESS]
     }
 
     def "should handle example tables with tag on second example"() {
         given:
-        def runtime = serenityRunnerForCucumberTestRunner(TablesAndExamplesTagsDoubleDigitsScenario.class, outputDirectory);
+        def runtime = serenityRunnerForCucumberTestRunner(RunOnlySecondExampleTableRows.class, outputDirectory);
 
         when:
         runtime.run();
@@ -360,13 +360,13 @@ class WhenCreatingSerenityTestOutcomesForTableDrivenScenarios extends Specificat
         def testOutcome = recordedTestOutcomes[0]
 
         then:
-        testOutcome.getTags().collect{testTag-> testTag.normalisedName()}.contains("double_digits")
+        testOutcome.getTags().collect{testTag-> testTag.normalisedName()}.contains("example_two")
         testOutcome.dataTable.rows.collect { it.result } == [SUCCESS, SUCCESS, SUCCESS]
     }
 
     def "should handle example tables with tags on scenario outline"() {
         given:
-        def runtime = serenityRunnerForCucumberTestRunner(TablesAndExamplesTagsManyAdditionsScenario.class, outputDirectory);
+        def runtime = serenityRunnerForCucumberTestRunner(RunAllExamplesThatInheritsScenarioOutlineTagOnly.class, outputDirectory);
 
         when:
         runtime.run();
@@ -375,14 +375,14 @@ class WhenCreatingSerenityTestOutcomesForTableDrivenScenarios extends Specificat
 
         then:
         def testTagNames = testOutcome.getTags().collect{testTag-> testTag.normalisedName()};
-        testTagNames.contains("single_digits")
-        testTagNames.contains("double_digits")
+        testTagNames.contains("example_one")
+        testTagNames.contains("example_two")
         testOutcome.dataTable.rows.collect { it.result } == [SUCCESS, SUCCESS, SUCCESS, SUCCESS, SUCCESS]
     }
 
     def "should handle example tables with tags on scenario outline and on example"() {
         given:
-        def runtime = serenityRunnerForCucumberTestRunner(TablesAndExamplesTagsOutlineAndExampleScenario.class, outputDirectory);
+        def runtime = serenityRunnerForCucumberTestRunner(RunExampleMatchingBothScenarioOutlineAndSecondExampleTagOnly.class, outputDirectory);
 
         when:
         runtime.run();
@@ -391,15 +391,15 @@ class WhenCreatingSerenityTestOutcomesForTableDrivenScenarios extends Specificat
 
         then:
         def testTagNames = testOutcome.getTags().collect{testTag-> testTag.normalisedName()};
-        testTagNames.contains("many_additions")
-        testTagNames.contains("double_digits")
+        testTagNames.contains("scenario_outline")
+        testTagNames.contains("example_two")
         testOutcome.dataTable.rows.collect { it.result } == [SUCCESS, SUCCESS, SUCCESS]
 
     }
 
 	def "should run all the examples that inherits a feature tag"() {
 		given:
-		def runtime = serenityRunnerForCucumberTestRunner(RunExamplesMatchingFeatureTag.class, outputDirectory);
+		def runtime = serenityRunnerForCucumberTestRunner(RunAllExamplesThatInheritsFeatureTag.class, outputDirectory);
 
 		when:
 		runtime.run();
@@ -408,8 +408,8 @@ class WhenCreatingSerenityTestOutcomesForTableDrivenScenarios extends Specificat
 
 		then:
 		def testTagNames = testOutcome.getTags().collect{testTag-> testTag.normalisedName()};
-		testTagNames.contains("single_digits")
-		testTagNames.contains("double_digits")
+		testTagNames.contains("example_one")
+		testTagNames.contains("example_two")
 		testOutcome.dataTable.rows.collect { it.result } == [SUCCESS, SUCCESS, SUCCESS, SUCCESS, SUCCESS]
 	}
 
@@ -424,8 +424,8 @@ class WhenCreatingSerenityTestOutcomesForTableDrivenScenarios extends Specificat
 
 		then:
 		def testTagNames = testOutcome.getTags().collect{testTag-> testTag.normalisedName()};
-		testTagNames.contains("single_digits")
-		testTagNames.contains("double_digits")
+		testTagNames.contains("example_one")
+		testTagNames.contains("example_two")
 		testOutcome.dataTable.rows.collect { it.result } == [SUCCESS, SUCCESS, SUCCESS, SUCCESS, SUCCESS]
 	}
 
@@ -440,7 +440,7 @@ class WhenCreatingSerenityTestOutcomesForTableDrivenScenarios extends Specificat
 
 		then:
 		def testTagNames = testOutcome.getTags().collect{testTag-> testTag.normalisedName()};
-		testTagNames.contains("single_digits")
+		testTagNames.contains("example_one")
 		testOutcome.dataTable.rows.collect { it.result } == [SUCCESS, SUCCESS]
 	}
 
@@ -455,8 +455,8 @@ class WhenCreatingSerenityTestOutcomesForTableDrivenScenarios extends Specificat
 
         then:
         def testTagNames = testOutcome.getTags().collect{testTag-> testTag.normalisedName()};
-        testTagNames.contains("single_digits")
-        testTagNames.contains("double_digits")
+        testTagNames.contains("example_one")
+        testTagNames.contains("example_two")
         testOutcome.dataTable.rows.collect { it.result } == [SUCCESS, SUCCESS, SUCCESS, SUCCESS, SUCCESS]
    }
 
@@ -471,8 +471,8 @@ class WhenCreatingSerenityTestOutcomesForTableDrivenScenarios extends Specificat
 
         then:
         def testTagNames = testOutcome.getTags().collect{testTag-> testTag.normalisedName()};
-        testTagNames.contains("single_digits")
-        testTagNames.contains("double_digits")
+        testTagNames.contains("example_one")
+        testTagNames.contains("example_two")
         testOutcome.dataTable.rows.collect { it.result } == [SUCCESS, SUCCESS, SUCCESS, SUCCESS, SUCCESS]
    }
 
@@ -487,7 +487,7 @@ class WhenCreatingSerenityTestOutcomesForTableDrivenScenarios extends Specificat
 
 		then:
 		def testTagNames = testOutcome.getTags().collect{testTag-> testTag.normalisedName()};
-		testTagNames.contains("double_digits")
+		testTagNames.contains("example_two")
 		testOutcome.dataTable.rows.collect { it.result } == [SUCCESS, SUCCESS, SUCCESS]
 	}
 
@@ -502,7 +502,7 @@ class WhenCreatingSerenityTestOutcomesForTableDrivenScenarios extends Specificat
 
         then:
         def testTagNames = testOutcome.getTags().collect{testTag-> testTag.normalisedName()};
-        testTagNames.contains("double_digits")
+        testTagNames.contains("example_two")
         testOutcome.dataTable.rows.collect { it.result } == [SUCCESS, SUCCESS, SUCCESS]
    }
 
@@ -517,7 +517,22 @@ class WhenCreatingSerenityTestOutcomesForTableDrivenScenarios extends Specificat
 
 		then:
 		def testTagNames = testOutcome.getTags().collect{testTag-> testTag.normalisedName()};
-		testTagNames.contains("single_digits")
+		testTagNames.contains("example_one")
+		testOutcome.dataTable.rows.collect { it.result } == [SUCCESS, SUCCESS]
+	}
+
+	def "should generate correct test outcome when only root directory of feature file is provided"() {
+		given:
+		def runtime = serenityRunnerForCucumberTestRunner(ScenarioWithOnlyFeatureFileRootDirectoryPath.class, outputDirectory);
+
+		when:
+		runtime.run();
+		def recordedTestOutcomes = new TestOutcomeLoader().forFormat(OutcomeFormat.JSON).loadFrom(outputDirectory);
+		def testOutcome = recordedTestOutcomes[0]
+
+		then:
+		def testTagNames = testOutcome.getTags().collect{testTag-> testTag.normalisedName()};
+		testTagNames.contains("example_one")
 		testOutcome.dataTable.rows.collect { it.result } == [SUCCESS, SUCCESS]
 	}
 

--- a/src/test/java/net/serenitybdd/cucumber/integration/RunAllExamplesThatInheritsFeatureTag.java
+++ b/src/test/java/net/serenitybdd/cucumber/integration/RunAllExamplesThatInheritsFeatureTag.java
@@ -8,5 +8,5 @@ import org.junit.runner.RunWith;
  * Created by Ramanathan Raghunathan on 18/12/2017.
  */
 @RunWith(CucumberWithSerenity.class)
-@CucumberOptions(features="src/test/resources/features/calculator/basic_arithmetic_with_tables_and_examples_tags.feature",tags = {"@foo"})
-public class RunExamplesMatchingFeatureTag {}
+@CucumberOptions(features="src/test/resources/features/calculator/basic_arithmetic_with_tables_and_examples_tags.feature",tags = {"@feature"})
+public class RunAllExamplesThatInheritsFeatureTag {}

--- a/src/test/java/net/serenitybdd/cucumber/integration/RunAllExamplesThatInheritsScenarioOutlineTagOnly.java
+++ b/src/test/java/net/serenitybdd/cucumber/integration/RunAllExamplesThatInheritsScenarioOutlineTagOnly.java
@@ -8,5 +8,5 @@ import org.junit.runner.RunWith;
  * Created by john on 23/07/2014.
  */
 @RunWith(CucumberWithSerenity.class)
-@CucumberOptions(features="src/test/resources/features/calculator/basic_arithmetic_with_tables_and_examples_tags.feature",tags = {"@double_digits"})
-public class TablesAndExamplesTagsDoubleDigitsScenario {}
+@CucumberOptions(features="src/test/resources/features/calculator/basic_arithmetic_with_tables_and_examples_tags.feature",tags = {"@scenario_outline"})
+public class RunAllExamplesThatInheritsScenarioOutlineTagOnly {}

--- a/src/test/java/net/serenitybdd/cucumber/integration/RunExampleMatchingBothScenarioOutlineAndSecondExampleTagOnly.java
+++ b/src/test/java/net/serenitybdd/cucumber/integration/RunExampleMatchingBothScenarioOutlineAndSecondExampleTagOnly.java
@@ -8,5 +8,5 @@ import org.junit.runner.RunWith;
  * Created by john on 23/07/2014.
  */
 @RunWith(CucumberWithSerenity.class)
-@CucumberOptions(features="src/test/resources/features/calculator/basic_arithmetic_with_tables_and_examples_tags.feature",tags = {"@many_additions"})
-public class TablesAndExamplesTagsManyAdditionsScenario {}
+@CucumberOptions(features="src/test/resources/features/calculator/basic_arithmetic_with_tables_and_examples_tags.feature",tags = {"@scenario_outline and @example_two"})
+public class RunExampleMatchingBothScenarioOutlineAndSecondExampleTagOnly {}

--- a/src/test/java/net/serenitybdd/cucumber/integration/RunExamplesMatchingExampleOrScenarioOutlineTagAndAnExampleTag.java
+++ b/src/test/java/net/serenitybdd/cucumber/integration/RunExamplesMatchingExampleOrScenarioOutlineTagAndAnExampleTag.java
@@ -8,5 +8,5 @@ import org.junit.runner.RunWith;
  * Created by Ramanathan Raghunathan on 18/12/2017.
  */
 @RunWith(CucumberWithSerenity.class)
-@CucumberOptions(features="src/test/resources/features/calculator/basic_arithmetic_with_tables_and_examples_tags.feature",tags = {"(@foo or @many_additions) and @double_digits"})
+@CucumberOptions(features="src/test/resources/features/calculator/basic_arithmetic_with_tables_and_examples_tags.feature",tags = {"(@feature or @scenario_outline) and @example_two"})
 public class RunExamplesMatchingExampleOrScenarioOutlineTagAndAnExampleTag {}

--- a/src/test/java/net/serenitybdd/cucumber/integration/RunExamplesMatchingExampleOrScenarioOutlineTagButNotAnExampleTag.java
+++ b/src/test/java/net/serenitybdd/cucumber/integration/RunExamplesMatchingExampleOrScenarioOutlineTagButNotAnExampleTag.java
@@ -8,5 +8,5 @@ import org.junit.runner.RunWith;
  * Created by Ramanathan Raghunathan on 18/12/2017.
  */
 @RunWith(CucumberWithSerenity.class)
-@CucumberOptions(features="src/test/resources/features/calculator/basic_arithmetic_with_tables_and_examples_tags.feature",tags = {"(@foo or @many_additions) and not @single_digits"})
+@CucumberOptions(features="src/test/resources/features/calculator/basic_arithmetic_with_tables_and_examples_tags.feature",tags = {"(@feature or @scenario_outline) and not @example_one"})
 public class RunExamplesMatchingExampleOrScenarioOutlineTagButNotAnExampleTag {}

--- a/src/test/java/net/serenitybdd/cucumber/integration/RunExamplesMatchingFeatureAndExampleTags.java
+++ b/src/test/java/net/serenitybdd/cucumber/integration/RunExamplesMatchingFeatureAndExampleTags.java
@@ -8,5 +8,5 @@ import org.junit.runner.RunWith;
  * Created by Ramanathan Raghunathan on 18/12/2017.
  */
 @RunWith(CucumberWithSerenity.class)
-@CucumberOptions(features="src/test/resources/features/calculator/basic_arithmetic_with_tables_and_examples_tags.feature",tags = {"@foo and @single_digits"})
+@CucumberOptions(features="src/test/resources/features/calculator/basic_arithmetic_with_tables_and_examples_tags.feature",tags = {"@feature and @example_one"})
 public class RunExamplesMatchingFeatureAndExampleTags {}

--- a/src/test/java/net/serenitybdd/cucumber/integration/RunExamplesMatchingFeatureLevelAndOutlineLevelTags.java
+++ b/src/test/java/net/serenitybdd/cucumber/integration/RunExamplesMatchingFeatureLevelAndOutlineLevelTags.java
@@ -8,5 +8,5 @@ import org.junit.runner.RunWith;
  * Created by Ramanathan Raghunathan on 18/12/2017.
  */
 @RunWith(CucumberWithSerenity.class)
-@CucumberOptions(features="src/test/resources/features/calculator/basic_arithmetic_with_tables_and_examples_tags.feature",tags = {"@foo and @many_additions"})
+@CucumberOptions(features="src/test/resources/features/calculator/basic_arithmetic_with_tables_and_examples_tags.feature",tags = {"@feature and @scenario_outline"})
 public class RunExamplesMatchingFeatureLevelAndOutlineLevelTags {}

--- a/src/test/java/net/serenitybdd/cucumber/integration/RunExamplesMatchingFeatureLevelOrOutlineLevelTags.java
+++ b/src/test/java/net/serenitybdd/cucumber/integration/RunExamplesMatchingFeatureLevelOrOutlineLevelTags.java
@@ -8,5 +8,5 @@ import org.junit.runner.RunWith;
  * Created by Ramanathan Raghunathan on 18/12/2017.
  */
 @RunWith(CucumberWithSerenity.class)
-@CucumberOptions(features="src/test/resources/features/calculator/basic_arithmetic_with_tables_and_examples_tags.feature",tags = {"@foo or @many_additions"})
+@CucumberOptions(features="src/test/resources/features/calculator/basic_arithmetic_with_tables_and_examples_tags.feature",tags = {"@feature or @scenario_outline"})
 public class RunExamplesMatchingFeatureLevelOrOutlineLevelTags {}

--- a/src/test/java/net/serenitybdd/cucumber/integration/RunExamplesMatchingFeatureOrExampleTags.java
+++ b/src/test/java/net/serenitybdd/cucumber/integration/RunExamplesMatchingFeatureOrExampleTags.java
@@ -8,5 +8,5 @@ import org.junit.runner.RunWith;
  * Created by Ramanathan Raghunathan on 18/12/2017.
  */
 @RunWith(CucumberWithSerenity.class)
-@CucumberOptions(features="src/test/resources/features/calculator/basic_arithmetic_with_tables_and_examples_tags.feature",tags = {"@foo or @single_digits"})
+@CucumberOptions(features="src/test/resources/features/calculator/basic_arithmetic_with_tables_and_examples_tags.feature",tags = {"@feature or @example_one"})
 public class RunExamplesMatchingFeatureOrExampleTags {}

--- a/src/test/java/net/serenitybdd/cucumber/integration/RunExamplesMatchingFeatureTagButNotAnExampleTag.java
+++ b/src/test/java/net/serenitybdd/cucumber/integration/RunExamplesMatchingFeatureTagButNotAnExampleTag.java
@@ -8,5 +8,5 @@ import org.junit.runner.RunWith;
  * Created by Ramanathan Raghunathan on 18/12/2017.
  */
 @RunWith(CucumberWithSerenity.class)
-@CucumberOptions(features="src/test/resources/features/calculator/basic_arithmetic_with_tables_and_examples_tags.feature",tags = {"@foo and not @double_digits"})
+@CucumberOptions(features="src/test/resources/features/calculator/basic_arithmetic_with_tables_and_examples_tags.feature",tags = {"@feature and not @example_two"})
 public class RunExamplesMatchingFeatureTagButNotAnExampleTag {}

--- a/src/test/java/net/serenitybdd/cucumber/integration/RunOnlyFirstExampleTableRows.java
+++ b/src/test/java/net/serenitybdd/cucumber/integration/RunOnlyFirstExampleTableRows.java
@@ -8,5 +8,5 @@ import org.junit.runner.RunWith;
  * Created by john on 23/07/2014.
  */
 @RunWith(CucumberWithSerenity.class)
-@CucumberOptions(features="src/test/resources/features/calculator/basic_arithmetic_with_tables_and_examples_tags.feature",tags = {"@single_digits"})
-public class TablesAndExamplesTagsSingleDigitsScenario {}
+@CucumberOptions(features="src/test/resources/features/calculator/basic_arithmetic_with_tables_and_examples_tags.feature",tags = {"@example_one"})
+public class RunOnlyFirstExampleTableRows {}

--- a/src/test/java/net/serenitybdd/cucumber/integration/RunOnlySecondExampleTableRows.java
+++ b/src/test/java/net/serenitybdd/cucumber/integration/RunOnlySecondExampleTableRows.java
@@ -8,5 +8,5 @@ import org.junit.runner.RunWith;
  * Created by john on 23/07/2014.
  */
 @RunWith(CucumberWithSerenity.class)
-@CucumberOptions(features="src/test/resources/features/calculator/basic_arithmetic_with_tables_and_examples_tags.feature",tags = {"@many_additions and @double_digits"})
-public class TablesAndExamplesTagsOutlineAndExampleScenario {}
+@CucumberOptions(features="src/test/resources/features/calculator/basic_arithmetic_with_tables_and_examples_tags.feature",tags = {"@example_two"})
+public class RunOnlySecondExampleTableRows {}

--- a/src/test/java/net/serenitybdd/cucumber/integration/ScenarioWithOnlyFeatureFileRootDirectoryPath.java
+++ b/src/test/java/net/serenitybdd/cucumber/integration/ScenarioWithOnlyFeatureFileRootDirectoryPath.java
@@ -1,0 +1,12 @@
+package net.serenitybdd.cucumber.integration;
+
+import cucumber.api.CucumberOptions;
+import net.serenitybdd.cucumber.CucumberWithSerenity;
+import org.junit.runner.RunWith;
+
+/**
+ * Created by Ramanathan Raghunathan on 06/01/2018.
+ */
+@RunWith(CucumberWithSerenity.class)
+@CucumberOptions(features="src/test/resources/features",tags = {"@feature and @example_one"})
+public class ScenarioWithOnlyFeatureFileRootDirectoryPath {}

--- a/src/test/resources/features/calculator/basic_arithmetic_with_tables_and_examples_tags.feature
+++ b/src/test/resources/features/calculator/basic_arithmetic_with_tables_and_examples_tags.feature
@@ -1,10 +1,10 @@
-@foo
+@feature
 Feature: Basic Arithmetic with tables
   In order to do my maths homework
   As a maths student
   I want to be able to add sums
 
-  @many_additions
+  @scenario_outline
   Scenario Outline: Many additions
     Given a calculator I just turned on
     And the previous entries:
@@ -16,14 +16,14 @@ Feature: Basic Arithmetic with tables
     And I press +
     Then the result is <c>
 
-  @single_digits
+  @example_one
   Examples: Single digits
   With just one digit
     | a | b | c  |
     | 1 | 2 | 8  |
     | 2 | 3 | 10 |
 
-  @double_digits
+  @example_two
   Examples: Double digits
   With more digits than one
     | a  | b  | c  |


### PR DESCRIPTION
Before this PR, the serenity-cucumber would generate serenity test outcome report only if the serenity-cucumber user has provided the absolute path of the feature file in the cucumber options in the JUnit tests. After this PR, the serenity-cucumber user could only provide the root folder of the feature file in cucumber options in JUnit tests and continue to reap the benefits of Serenity's test outcome report. Unit tests and integration tests are added to test this change and have been successful. Some of the existing related tests had to be refactored to support testing of this change.