### PR TITLE
feat #165 - Further refinements to cucumber-based batching

### DIFF
--- a/src/main/java/net/serenitybdd/cucumber/suiteslicing/CucumberScenarioLoader.java
+++ b/src/main/java/net/serenitybdd/cucumber/suiteslicing/CucumberScenarioLoader.java
@@ -71,7 +71,7 @@ public class CucumberScenarioLoader {
 
     private int scenarioCountFor(ScenarioDefinition scenarioDefinition) {
         if (scenarioDefinition instanceof ScenarioOutline) {
-            return ((ScenarioOutline) scenarioDefinition).getExamples().get(0).getTableBody().size();
+            return ((ScenarioOutline) scenarioDefinition).getExamples().stream().map(examples -> examples.getTableBody().size()).mapToInt(Integer::intValue).sum();
         } else {
             return 1;
         }

--- a/src/main/java/net/serenitybdd/cucumber/suiteslicing/ScenarioLineCountStatistics.java
+++ b/src/main/java/net/serenitybdd/cucumber/suiteslicing/ScenarioLineCountStatistics.java
@@ -71,7 +71,8 @@ public class ScenarioLineCountStatistics implements TestStatistics {
         final int stepCount;
         if (scenarioDefinition instanceof ScenarioOutline) {
             ScenarioOutline outline = (ScenarioOutline) scenarioDefinition;
-            stepCount = outline.getExamples().get(0).getTableBody().size() * (backgroundStepCount + outline.getSteps().size());
+            Integer exampleCount = outline.getExamples().stream().map(examples -> examples.getTableBody().size()).mapToInt(Integer::intValue).sum();
+            stepCount = exampleCount * (backgroundStepCount + outline.getSteps().size());
         } else {
             stepCount = backgroundStepCount + scenarioDefinition.getSteps().size();
         }

--- a/src/main/java/net/serenitybdd/cucumber/suiteslicing/VisualisableCucumberScenarios.java
+++ b/src/main/java/net/serenitybdd/cucumber/suiteslicing/VisualisableCucumberScenarios.java
@@ -3,10 +3,6 @@ package net.serenitybdd.cucumber.suiteslicing;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
-import java.util.List;
-import java.util.stream.IntStream;
-
-import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals;
 
 public class VisualisableCucumberScenarios extends WeightedCucumberScenarios {
@@ -37,12 +33,6 @@ public class VisualisableCucumberScenarios extends WeightedCucumberScenarios {
     @Override
     public String toString() {
         return ToStringBuilder.reflectionToString(this);
-    }
-
-    public static List<VisualisableCucumberScenarios> visualise(int forkCount, List<WeightedCucumberScenarios> slices) {
-        return slices.stream()
-            .map(slice -> IntStream.rangeClosed(1, forkCount).mapToObj(forkNumber -> create(slices.indexOf(slice) + 1, forkNumber, slice.slice(forkNumber).of(forkCount)))
-                .collect(toList())).flatMap(List::stream).collect(toList());
     }
 
 }

--- a/src/smoketests/pom.xml
+++ b/src/smoketests/pom.xml
@@ -11,9 +11,9 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <serenity.version>1.9.0-rc.3</serenity.version>
-        <serenity.maven.version>1.9.0-rc.3</serenity.maven.version>
-        <serenity.cucumber.version>1.6.11-SNAPSHOT</serenity.cucumber.version>
+        <serenity.version>1.9.37</serenity.version>
+        <serenity.maven.version>1.9.6</serenity.maven.version>
+        <serenity.cucumber.version>1.9.16-SNAPSHOT</serenity.cucumber.version>
         <encoding>UTF-8</encoding>
         <parallel.tests>4</parallel.tests>
     </properties>
@@ -98,7 +98,7 @@
                 </configuration>
             </plugin>
             <plugin>
-                <artifactId>maven-failsafe-plugin</artifactId>
+                    <artifactId>maven-failsafe-plugin</artifactId>
                 <version>2.20</version>
                 <configuration>
                     <includes>
@@ -106,6 +106,7 @@
                     </includes>
                     <systemPropertyVariables>
                         <webdriver.base.url>${webdriver.base.url}</webdriver.base.url>
+                        <fork.count>5</fork.count>
                     </systemPropertyVariables>
                     <parallel>classes</parallel>
                     <threadCount>${parallel.tests}</threadCount>

--- a/src/test/java/net/serenitybdd/cucumber/suiteslicing/CucumberSliceVisualiserTest.java
+++ b/src/test/java/net/serenitybdd/cucumber/suiteslicing/CucumberSliceVisualiserTest.java
@@ -1,24 +1,11 @@
 package net.serenitybdd.cucumber.suiteslicing;
 
-import com.google.gson.GsonBuilder;
-
 import net.thucydides.core.annotations.Narrative;
 import net.thucydides.core.guice.Injectors;
 import net.thucydides.core.util.EnvironmentVariables;
 
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.List;
-
-import static com.google.common.collect.Lists.newArrayList;
-import static net.thucydides.core.ThucydidesSystemProperty.SERENITY_OUTPUT_DIRECTORY;
 
 @Narrative(text = "There are no assertions in this test, but this is a useful tool for generating a visualisation of how a specific test slicing "
                   + "configuration will be executed as part of a running test. The test methods below allow a number of parameters to be input and when the test is run"
@@ -28,54 +15,40 @@ import static net.thucydides.core.ThucydidesSystemProperty.SERENITY_OUTPUT_DIREC
                   + "Variables that can be input here include feature root, number of slices, number of forks and test statistics (line count based or actual run data)")
 public class CucumberSliceVisualiserTest {
 
-    private final Logger LOGGER = LoggerFactory.getLogger(CucumberSliceVisualiserTest.class);
     private TestStatistics HISTORIC_RUN_STATISTICS;
     private TestStatistics LINE_COUNT_STATISTICS;
-    static EnvironmentVariables environmentVariables;
-    private static final String FEATURE_ROOT = "smoketests";
+    private EnvironmentVariables environmentVariables;
+    private CucumberScenarioVisualiser cucumberScenarioVisualiser;
+    private static final String FEATURE_ROOT = "classpath:smoketests";
 
-    @BeforeClass
-    public static void createDirectory() throws IOException {
-        environmentVariables = Injectors.getInjector().getInstance(EnvironmentVariables.class);
-        String outputDirectory = outputDirectory();
-        Files.createDirectories(Paths.get(outputDirectory));
-    }
-
-    private static String outputDirectory() {
-        return environmentVariables.getProperty(SERENITY_OUTPUT_DIRECTORY, "target/site/serenity");
-    }
 
     @Before
     public void setUp() {
         HISTORIC_RUN_STATISTICS = MultiRunTestStatistics.fromRelativePath("/statistics");
-        LINE_COUNT_STATISTICS = ScenarioLineCountStatistics.fromFeaturePath("classpath:" + FEATURE_ROOT);
+        LINE_COUNT_STATISTICS = ScenarioLineCountStatistics.fromFeaturePath(FEATURE_ROOT);
+        environmentVariables = Injectors.getInjector().getInstance(EnvironmentVariables.class);
+        cucumberScenarioVisualiser = new CucumberScenarioVisualiser(environmentVariables);
+    }
+
+    @Test
+    public void visualise1SliceWith4Forks() {
+        cucumberScenarioVisualiser.visualise(FEATURE_ROOT, 4, 2, HISTORIC_RUN_STATISTICS);
     }
 
     @Test
     public void visualise4SlicesWith2Forks() {
-        visualise(FEATURE_ROOT, 4, 2, HISTORIC_RUN_STATISTICS);
+        cucumberScenarioVisualiser.visualise(FEATURE_ROOT, 4, 2, HISTORIC_RUN_STATISTICS);
     }
 
     @Test
     public void visualise5SlicesWith1ForkBasedOnRunStats() {
-        visualise(FEATURE_ROOT, 5, 1, HISTORIC_RUN_STATISTICS);
+        cucumberScenarioVisualiser.visualise(FEATURE_ROOT, 5, 1, HISTORIC_RUN_STATISTICS);
     }
 
     @Test
     public void visualise5SlicesWith1ForkBasedOnLineCount() {
-        visualise(FEATURE_ROOT, 5, 1, LINE_COUNT_STATISTICS);
+        cucumberScenarioVisualiser.visualise(FEATURE_ROOT, 5, 1, LINE_COUNT_STATISTICS);
     }
 
-    public void visualise(String rootFolder, int sliceCount, int forkCount, TestStatistics testStatistics) {
-        List<WeightedCucumberScenarios> slices = new CucumberScenarioLoader(newArrayList("classpath:" + rootFolder), testStatistics).load().sliceInto(sliceCount);
-        List<VisualisableCucumberScenarios> visualisedSlices = VisualisableCucumberScenarios.visualise(forkCount, slices);
-        String jsonFile = String.format("%s/%s-slice-config-%s-forks-in-each-of-%s-slices-using-%s.json", outputDirectory(), rootFolder, forkCount, sliceCount, testStatistics);
-        try {
-            Files.write(Paths.get(jsonFile), new GsonBuilder().setPrettyPrinting().create().toJson(visualisedSlices).getBytes());
-            LOGGER.info("Wrote fork slice as JSON for {} slices -> {}", visualisedSlices.size(), jsonFile);
-        } catch (Exception e) {
-            throw new RuntimeException("failed to create suite slices", e);
-        }
-    }
 
 }

--- a/src/test/java/net/serenitybdd/cucumber/suiteslicing/ScenarioLineCountStatisticsTest.java
+++ b/src/test/java/net/serenitybdd/cucumber/suiteslicing/ScenarioLineCountStatisticsTest.java
@@ -36,7 +36,12 @@ public class ScenarioLineCountStatisticsTest {
 
     @Test
     public void scenarioWeightForScenarioWithBackgroundAndScenarioOutline() {
-        assertThat(stats.scenarioWeightFor("Buying things", "Buying more widgets"), is(new BigDecimal("15")));
+        assertThat(stats.scenarioWeightFor("Buying things - with tables", "Buying more widgets"), is(new BigDecimal("15")));
+    }
+
+    @Test
+    public void scenarioWeightForScenarioOutlineWithMultipleExamples() {
+        assertThat(stats.scenarioWeightFor("Buying things - with tables", "Buying lots of widgets"), is(new BigDecimal("35")));
     }
 
     @Test

--- a/src/test/java/net/serenitybdd/cucumber/suiteslicing/SlicedTestRunner.java
+++ b/src/test/java/net/serenitybdd/cucumber/suiteslicing/SlicedTestRunner.java
@@ -1,0 +1,35 @@
+package net.serenitybdd.cucumber.suiteslicing;
+
+import net.serenitybdd.cucumber.CucumberWithSerenity;
+import net.thucydides.core.ThucydidesSystemProperty;
+import net.thucydides.core.guice.Injectors;
+import net.thucydides.core.util.EnvironmentVariables;
+
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+import cucumber.api.CucumberOptions;
+
+@RunWith(CucumberWithSerenity.class)
+@CucumberOptions(glue = "net.serenitybdd.cucumber.smoketests", features="classpath:smoketests")
+public class SlicedTestRunner {
+
+//    @BeforeClass
+//    public static void setUp() {
+//        EnvironmentVariables environmentVariables = Injectors.getInjector().getInstance(EnvironmentVariables.class);
+//        environmentVariables.setProperty(ThucydidesSystemProperty.SERENITY_BATCH_SIZE);
+//        ThucydidesSystemProperty.SERENITY_BATCH_SIZE.
+//        System.setProperty("BAT_FORK_NUMBER", System.getenv("BAT_ENV_fork_number"));
+//        System.setProperty("BAT_TOTAL_FORKS", System.getenv("BAT_ENV_fork_count"));
+//        BeforeAll.configureOptions();
+//        String bat_fork_number = System.getProperty("BAT_FORK_NUMBER");
+//        if ("0".equals(bat_fork_number) && TestEnvironmentConfig.TEST_ENV.isDevOrPreview()) {
+//            TimeMachineClient timeMachineClient = new TimeMachineClient();
+//            timeMachineClient.resetTime(true);
+//            clearDownDb();
+//        }
+//
+//        ensureAgentAccount(bat_fork_number);
+//    }
+
+}

--- a/src/test/java/net/serenitybdd/cucumber/suiteslicing/SlicedTestRunner.java
+++ b/src/test/java/net/serenitybdd/cucumber/suiteslicing/SlicedTestRunner.java
@@ -1,11 +1,7 @@
 package net.serenitybdd.cucumber.suiteslicing;
 
 import net.serenitybdd.cucumber.CucumberWithSerenity;
-import net.thucydides.core.ThucydidesSystemProperty;
-import net.thucydides.core.guice.Injectors;
-import net.thucydides.core.util.EnvironmentVariables;
 
-import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 
 import cucumber.api.CucumberOptions;
@@ -14,22 +10,18 @@ import cucumber.api.CucumberOptions;
 @CucumberOptions(glue = "net.serenitybdd.cucumber.smoketests", features="classpath:smoketests")
 public class SlicedTestRunner {
 
-//    @BeforeClass
-//    public static void setUp() {
-//        EnvironmentVariables environmentVariables = Injectors.getInjector().getInstance(EnvironmentVariables.class);
-//        environmentVariables.setProperty(ThucydidesSystemProperty.SERENITY_BATCH_SIZE);
-//        ThucydidesSystemProperty.SERENITY_BATCH_SIZE.
-//        System.setProperty("BAT_FORK_NUMBER", System.getenv("BAT_ENV_fork_number"));
-//        System.setProperty("BAT_TOTAL_FORKS", System.getenv("BAT_ENV_fork_count"));
-//        BeforeAll.configureOptions();
-//        String bat_fork_number = System.getProperty("BAT_FORK_NUMBER");
-//        if ("0".equals(bat_fork_number) && TestEnvironmentConfig.TEST_ENV.isDevOrPreview()) {
-//            TimeMachineClient timeMachineClient = new TimeMachineClient();
-//            timeMachineClient.resetTime(true);
-//            clearDownDb();
-//        }
-//
-//        ensureAgentAccount(bat_fork_number);
-//    }
+/*
+
+Experimental test runner where parameters can changed in order to run specific portions of the test suite. For instance create a run configuration and paste the following into the VM Options:
+
+-Dserenity.batch.count=3 -Dserenity.batch.number=2 -Dserenity.fork.number=2 -Dserenity.fork.count=1 -Dserenity.test.statistics.dir=/statistics
+
+And you should see the following logged in the console:
+
+16:49:18.551 [main] INFO  n.s.cucumber.CucumberWithSerenity - Running slice 2 of 3 using fork 1 of 2 from feature paths [classpath:smoketests]
+
+The Test output should show some features selected and some scenarios run and some not run. This is expected!
+
+*/
 
 }

--- a/src/test/resources/samples/data_driven_scenario.feature
+++ b/src/test/resources/samples/data_driven_scenario.feature
@@ -1,4 +1,4 @@
-Feature: Buying things
+Feature: Buying things - data driven
 
   Scenario: Buying lots of widgets
     Given I want to purchase the following gizmos:

--- a/src/test/resources/samples/screenplay_table_based_scenario_with_errors.feature
+++ b/src/test/resources/samples/screenplay_table_based_scenario_with_errors.feature
@@ -1,4 +1,4 @@
-Feature: Buying things
+Feature: Buying things - with tables and errors
 
   Scenario Outline: Buying lots of widgets
     Given I want to purchase <amount> gizmos

--- a/src/test/resources/samples/screenplay_table_based_scenario_with_failures.feature
+++ b/src/test/resources/samples/screenplay_table_based_scenario_with_failures.feature
@@ -1,4 +1,4 @@
-Feature: Buying things
+Feature: Buying things - with tables and failures
 
   Scenario Outline: Buying lots of widgets
     Given I want to purchase <amount> gizmos

--- a/src/test/resources/samples/screenplay_table_based_scenario_with_failures_and_errors.feature
+++ b/src/test/resources/samples/screenplay_table_based_scenario_with_failures_and_errors.feature
@@ -1,4 +1,4 @@
-Feature: Buying things
+Feature: Buying things - with tables failures and errors
 
   Scenario Outline: Buying lots of widgets
     Given I want to purchase <amount> gizmos

--- a/src/test/resources/samples/simple_table_based_scenario.feature
+++ b/src/test/resources/samples/simple_table_based_scenario.feature
@@ -1,4 +1,4 @@
-Feature: Buying things
+Feature: Buying things - with tables
 
   Background: I already have some cash
     Given I have $100

--- a/src/test/resources/samples/table_based_scenario_with_failures.feature
+++ b/src/test/resources/samples/table_based_scenario_with_failures.feature
@@ -1,4 +1,4 @@
-Feature: Buying things
+Feature: Buying things - with tables and failures screenplay
 
   Scenario Outline: Buying lots of widgets
     An error is thrown when the cost is negative


### PR DESCRIPTION
- See updated documentation on https://serenity-bdd.github.io/theserenitybook/0.1.0/serenity-parallel.html
- Fixed calculation of step count for when scenario outline has more than 1 Examples table.
- Mismatch between the number of scenarios included and the expected number of scenarios is now logged as a warning rather than an exception.
- CucumberScenarioVisualiser class created to allow users to create simple visualisations of their own such as CucumberSliceVisualiserTest.
- features and scenarios in samples/ have been renamed to remove ambiguities.
- TODO - Subdividing cucumber batches within a machine will not be picked up from gradle/maven fork settings, however test runners invoked directly will work providing system parameters are correctly set. See comments in src/test/java/net/serenitybdd/cucumber/suiteslicing/SlicedTestRunner.java about how to set system properties.