### PR TITLE
The same reports were generated multiple times when using Scenario Outline

### DIFF
--- a/src/main/java/cucumber/runtime/formatter/SerenityReporter.java
+++ b/src/main/java/cucumber/runtime/formatter/SerenityReporter.java
@@ -330,11 +330,7 @@ public class SerenityReporter implements Formatter {
     }
 
     private void handleTestRunFinished(TestRunFinished event) {
-        if (examplesRunning) {
-            finishExample();
-        } else {
-            generateReports();
-        }
+        generateReports();
         assureTestSuiteFinished();
     }
 
@@ -688,7 +684,6 @@ public class SerenityReporter implements Formatter {
         if (exampleCount == 0) {
             examplesRunning = false;
             setTableScenarioOutline();
-            generateReports();
         } else {
             examplesRunning = true;
         }


### PR DESCRIPTION
This should fix #170.

There is no test provided as it is a bit complicated for me to write it, but it was tested manually a it helped. Reports are not generated multiple times after each example from Scenario outline for each already processed scenario.

This bug is quite annoying as we have in our project over 1000 scenarios and many of them are scenario outlines with examples and then lot of report files are generated multiple times.